### PR TITLE
Updates to 2.2.3 release of osc.js and other random libraries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "readmeFilename": "README.md",
     "devDependencies": {
         "node-jqunit": "1.1.8",
-        "grunt": "1.0.2",
+        "grunt": "1.0.3",
         "eslint-config-fluid": "1.3.0",
         "fluid-grunt-eslint": "18.1.2",
         "grunt-jsonlint": "1.1.0",
@@ -30,10 +30,10 @@
         "grunt-contrib-uglify": "3.3.0"
     },
     "dependencies": {
-        "osc": "2.2.2",
+        "osc": "2.2.3",
         "infusion": "3.0.0-dev.20180326T173646Z.8c6a109b1",
         "express": "4.16.3",
-        "ws": "5.1.1",
+        "ws": "5.2.0",
         "gpii-launcher": "1.0.0-dev.20180305T114318Z.39049a4"
     },
     "scripts": {


### PR DESCRIPTION
This reportedly supports Node.js 10.x, due to upstream updates to the serialport library.